### PR TITLE
更方便地自定义运行端口

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
     - Step 1: 安装依赖
       - `pipenv install -r requirements.txt`
     - Step 2: 启动
+      - `pipenv shell` 
       - `python app.py [your-port]`
 4. Conda 环境启动
    - Step 1: 新建 Conda 环境

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@
       - `docker pull happyrespawnanchor/my-go-flask-project:24.4.17`
    - Step 2: 启动容器
       - `docker run -it -p 5000:5000 --rm -v /你自己/拥有的/视频位置:/mygo/video my-go-flask-project:24.4.17`（换成你的mygo视频路径） 
-* 最后访问 `127.0.0.1:` 即可，如果你更改了端口，此处的5000也记得改掉。
+* 最后访问 `127.0.0.1:5000` 即可，如果你更改了端口，此处的5000也记得改掉。
 ## 项目结构
 ### 技术框架
 `Python` + `Flask` + `Bootstrap` + `nPlayer`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 
 **常见问题**
 
-- 缺少视频资源：在云盘中找到“视频资源”文件夹下载后放在 `mygoFlaskProject/video` 文件夹下。
+- 缺少视频资源：在云盘中找到“视频资源”文件夹下载后放在 `mygoFlaskProject/video` 文件夹下。如果找不到这个文件夹，在项目根目录下创建video/文件夹即可。
 - 视频有声音黑屏：说明自己准备的视频是 v265 格式，这个目前只有新的浏览器支持，下载[谷歌浏览器](https://www.google.cn/chrome/index.html)解决。
 - 视频不加载+评论区不加载：原因是火绒的拦截策略，临时关掉火绒或者B站私聊，改一下代码即可。
 - 页面布局错乱：浏览器最大化后调整网页缩放即可。
@@ -73,20 +73,25 @@
    - Step 1: 安装依赖
      - `pip3 install -r requirements.txt`
    - Step 2: 启动
-     - `python app.py`
+     - `python app.py [your-port]`
+2. Pipenv 环境启动
+    - Step 1: 安装依赖
+      - `pipenv install -r requirements.txt`
+    - Step 2: 启动
+      - `python app.py [your-port]`
 2. Conda 环境启动
    - Step 1: 新建 Conda 环境
      - `conda create -n mygo python=3.10`
      - `conda activate mygo`
      - `pip install -r requirements.txt`
    - Step 2: 启动
-       - `python app.py` （若需更改端口，请编辑 `run_mode.json` 尾行的 `port`）
+       - `python app.py [your-port]`
 3. Docker 环境启动
    - Step 1: 拉取镜像：
       - `docker pull happyrespawnanchor/my-go-flask-project:24.4.17`
    - Step 2: 启动容器
       - `docker run -it -p 5000:5000 --rm -v /你自己/拥有的/视频位置:/mygo/video my-go-flask-project:24.4.17`（换成你的mygo视频路径） 
-* 最后访问 `127.0.0.1:5000` 即可，如果你更改了端口，此处的5000也记得改掉。
+* 最后访问 `127.0.0.1:` 即可，如果你更改了端口，此处的5000也记得改掉。
 ## 项目结构
 ### 技术框架
 `Python` + `Flask` + `Bootstrap` + `nPlayer`

--- a/README.md
+++ b/README.md
@@ -74,19 +74,19 @@
      - `pip3 install -r requirements.txt`
    - Step 2: 启动
      - `python app.py [your-port]`
-2. Pipenv 环境启动
+3. Pipenv 环境启动
     - Step 1: 安装依赖
       - `pipenv install -r requirements.txt`
     - Step 2: 启动
       - `python app.py [your-port]`
-2. Conda 环境启动
+4. Conda 环境启动
    - Step 1: 新建 Conda 环境
      - `conda create -n mygo python=3.10`
      - `conda activate mygo`
      - `pip install -r requirements.txt`
    - Step 2: 启动
        - `python app.py [your-port]`
-3. Docker 环境启动
+5. Docker 环境启动
    - Step 1: 拉取镜像：
       - `docker pull happyrespawnanchor/my-go-flask-project:24.4.17`
    - Step 2: 启动容器

--- a/app.py
+++ b/app.py
@@ -139,5 +139,5 @@ if __name__ == '__main__':
     except Exception as e:
         print(e)
         print("请检查传入参数是否有误！FlaskApp将自动在8080端口运行")
-        run_port = 8080
+        run_port = 5000
         app.run(host=run_ip, port=run_port)

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ f = open("basic.json", 'r')
 content = f.read()
 f.close()
 mygo_data = json.loads(content)
+
 # 运行模式
 f = open("run_mode.json", 'r')
 content = f.read()
@@ -23,6 +24,7 @@ f.close()
 run_mode = json.loads(content)['run_mode']
 run_ip = json.loads(content)['ip']
 run_port = json.loads(content)['port']
+
 # 视频本地路径列表
 mygo_video_list = []
 for item in os.listdir('video/'):
@@ -130,4 +132,12 @@ def danmu_server():
 
 
 if __name__ == '__main__':
-    app.run(host=run_ip, port=run_port)
+    try:
+        run_port = int(sys.argv[1])
+        app.run(host=run_ip, port=run_port)
+
+    except Exception as e:
+        print(e)
+        print("请检查传入参数是否有误！FlaskApp将自动在8080端口运行")
+        run_port = 8080
+        app.run(host=run_ip, port=run_port)

--- a/app.py
+++ b/app.py
@@ -138,6 +138,6 @@ if __name__ == '__main__':
 
     except Exception as e:
         print(e)
-        print("请检查传入参数是否有误！FlaskApp将自动在8080端口运行")
+        print("请检查传入参数是否有误！FlaskApp将自动在5000端口运行")
         run_port = 5000
         app.run(host=run_ip, port=run_port)

--- a/run.bat
+++ b/run.bat
@@ -1,2 +1,2 @@
 cd /d %~dp0
-python\python app.py
+python\python app.py 5000


### PR DESCRIPTION
现在可以直接python app.py [port] 了。因为我发现5000端口占用率其实挺高，我自己电脑上就是占用状态，所以我进行了更改。我在README、app.py、run.bat中均进行了修改，并且做了错误收集。如果不输入端口或者输入有错误的话会自动在5000端口运行。